### PR TITLE
rewrite 'help cmdname' text slightly

### DIFF
--- a/nagios-bot.py
+++ b/nagios-bot.py
@@ -56,11 +56,11 @@ class NagiosBot(bot.SimpleBot):
                     sendable_help_messages.append(abbreviated_help_message)
                 if len(sendable_help_messages) > 0:
                     if help_command != '':
-                        self.send_message(event.target, "%s: Here is usage for %s" % (event.source, help_command))
+                        self.send_message(event.target, "%s: Here is the help for '%s':" % (event.source, help_command))
                     for hc in sendable_help_messages:
-                        self.send_message(event.target, "%s" % (hc))
+                        self.send_message(event.target, "  %s" % (hc))
                 else:
-                    self.send_message(event.target, "%s: No help available for command %s " % (event.source, help_command))
+                    self.send_message(event.target, "%s: No help available for '%s'." % (event.source, help_command))
 
             else:
                 _is_found = False


### PR DESCRIPTION
- fixes a grammatical error
- remove a trailing whitespace
- quotes the provided command in the result
- make consistent response text across 'found' / 'notfound' cases
- indent actual commands in response by 2 characters to distinguish the list from pages/etc
