### PR TITLE
add inventory support for index and fqdn lookups

### DIFF
--- a/MozillaNagiosStatus.py
+++ b/MozillaNagiosStatus.py
@@ -69,6 +69,7 @@ class MozillaNagiosStatus:
         self.mklive_status_socket = MKLIVE_STATUS_SOCKET
         self.use_irc_hilight = USE_IRC_HILIGHT
         self.irc_hilight_nick = IRC_HILIGHT_NICK
+        self.inventory_url_prefix = INVENTORY_URL_PREFIX
 
 
         ##Start new thread to parse the nagios log file
@@ -126,6 +127,9 @@ class MozillaNagiosStatus:
         self.message_commands.append({'regex':'^(?:oncall|whoisoncall)\s+(.*)$', 'callback':self.get_oncallmk})
         self.message_commands.append({'regex':'^(?:oncall|whoisoncall)$', 'callback':self.get_oncallmk})
         #self.message_commands.append({'regex':'^whoisoncall$', 'callback':self.get_oncall})
+
+        self.message_commands.append({'regex':'^inv(?:entory)?\s+(?:for\s+)?(\d+)\s*$', 'callback':self.get_inventory_system_by_index})
+        self.message_commands.append({'regex':'^inv(?:entory)?\s+(?:for\s+)?(.*)\s*$', 'callback':self.get_inventory_system_by_name})
 
     ###Default entry point for each plugin. Simply returns a regex and which static method to call upon matching the regex
 
@@ -215,6 +219,33 @@ class MozillaNagiosStatus:
 
     def get_ack_number(self):
         return self.act_ct + self.list_offset
+
+    def inventory_system_url(host):
+        if host is not None and self.validate_host(host) is True:
+            return "%s%s" % (self.inventory_url_prefix, host)
+        else:
+            return None
+
+    def get_inventory_system_by_index(self, event, message, options):
+        host = None
+        try:
+            dict_object = self.ackable_list[int(options.group(1)) - self.list_offset]
+            host = dict_object['host']
+        except Exception, e:
+            return event.target, "%s: unable to inventory system index %s" % (event.source, e)
+        url = self.inventory_system_url(host)
+        if url is not None:
+            return event.target, "%s: inventory system %s is at %s" % (event.source, host, url)
+        else:
+            return event.target, "%s: unable to inventory system index %s" % (event.source, host)
+
+    def get_inventory_system_by_name(self, event, message, options):
+        host = options.group(1)
+        url = self.inventory_system_url(host)
+        if url is not None:
+            return event.target, "%s: inventory system %s is at %s" % (event.source, host, url)
+        else:
+            return event.target, "%s: unable to inventory system index %s" % (event.source, host)
 
     def downtime_by_index(self, event, message, options):
         timestamp = int(time.time())

--- a/settings_local.py-dist
+++ b/settings_local.py-dist
@@ -13,3 +13,4 @@ CHANNEL_GROUPS = {
     'nagioscontact':'#irc_channel_to_alert_to',
     }
 DEFAULT_CHANNEL_GROUP = '#default_channel'
+#INVENTORY_URL_PREFIX = 'https://inventory/core/search/#q='

--- a/t.pl
+++ b/t.pl
@@ -118,6 +118,32 @@ say((
         'oncall' =~ '^(?:oncall|whoisoncall)$'
     ) ? "ok" : 'not ok');
 
+say '# inventory';
+say((
+        'inv 1234' =~ '^inv(?:entory)?\s+(?:for\s+)?(\d+)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inv for 1234' =~ '^inv(?:entory)?\s+(?:for\s+)?(\d+)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inventory 1234' =~ '^inv(?:entory)?\s+(?:for\s+)?(\d+)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inventory for 1234' =~ '^inv(?:entory)?\s+(?:for\s+)?(\d+)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inv f.q.d.n' =~ '^inv(?:entory)?\s+(?:for\s+)?(.*)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inv for f.q.d.n' =~ '^inv(?:entory)?\s+(?:for\s+)?(.*)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inventory f.q.d.n' =~ '^inv(?:entory)?\s+(?:for\s+)?(.*)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+say((
+        'inventory for f.q.d.n' =~ '^inv(?:entory)?\s+(?:for\s+)?(.*)\s*$'
+    ) ? "ok -- $1" : 'not ok');
+
 say '# edge cases';
 say((
         'downtime host:service name 4d downtime host for 4d :)' =~ '^downtime\s+([^: ]+):(.+?)\s+(\d+[ydhms])\s+(.*)\s*$'


### PR DESCRIPTION
This is a draft implementation for #38 of basic 'inventory for 1234' support, so we can get direct links to inventory. It'll also list A/CNAME records, not just SYS records, which is a nice side effect.

Testing required, but this should be sufficient to ship for now until we have a way to search services (which aren't yet in inventory).
